### PR TITLE
v2.5

### DIFF
--- a/src/Cerberus/Cerberus.php
+++ b/src/Cerberus/Cerberus.php
@@ -52,10 +52,10 @@ class Cerberus
      *
      * @return bool
      */
-    public function can($permission, $requireAll = false)
+    public function hasPermission($permission, $requireAll = false)
     {
         if ($user = $this->user()) {
-            return $user->can($permission, $requireAll);
+            return $user->hasPermission($permission, $requireAll);
         }
 
         return false;
@@ -142,7 +142,7 @@ class Cerberus
         $filterName .= '_'.substr(md5($route), 0, 6);
 
         $closure = function () use ($permissions, $result, $requireAll) {
-            $hasPerm = $this->can($permissions, $requireAll);
+            $hasPerm = $this->hasPermission($permissions, $requireAll);
 
             if (!$hasPerm) {
                 return empty($result) ? $this->app->abort(403) : $result;
@@ -179,7 +179,7 @@ class Cerberus
 
         $closure = function () use ($roles, $permissions, $result, $requireAll) {
             $hasRole  = $this->hasRole($roles, $requireAll);
-            $hasPerms = $this->can($permissions, $requireAll);
+            $hasPerms = $this->hasPermission($permissions, $requireAll);
 
             if ($requireAll) {
                 $hasRolePerm = $hasRole && $hasPerms;

--- a/src/Cerberus/CerberusServiceProvider.php
+++ b/src/Cerberus/CerberusServiceProvider.php
@@ -68,13 +68,13 @@ class CerberusServiceProvider extends ServiceProvider
             return "<?php endif; // Cerberus::hasRole ?>";
         });
 
-        // Call to Cerberus::can
+        // Call to Cerberus::hasPermission
         \Blade::directive('permission', function ($expression) {
-            return "<?php if (\\Cerberus::can({$expression})) : ?>";
+            return "<?php if (\\Cerberus::hasPermission({$expression})) : ?>";
         });
 
         \Blade::directive('endpermission', function ($expression) {
-            return "<?php endif; // Cerberus::can ?>";
+            return "<?php endif; // Cerberus::hasPermission ?>";
         });
 
         // Call to Cerberus::ability

--- a/src/Cerberus/CerberusServiceProvider.php
+++ b/src/Cerberus/CerberusServiceProvider.php
@@ -8,7 +8,9 @@
  * @package Michalisantoniou6\Cerberus
  */
 
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\ServiceProvider;
+use Michalisantoniou6\Cerberus\Observers\UserObserver;
 
 class CerberusServiceProvider extends ServiceProvider
 {
@@ -37,6 +39,13 @@ class CerberusServiceProvider extends ServiceProvider
         }
 
         $this->bladeDirectives();
+
+        $this->registerUserObserver();
+    }
+
+    private function registerUserObserver() {
+        $userModel = app(Config::get('cerberus.user'));
+        $userModel::observe(UserObserver::class);
     }
 
     /**

--- a/src/Cerberus/Contracts/CerberusUserInterface.php
+++ b/src/Cerberus/Contracts/CerberusUserInterface.php
@@ -35,7 +35,7 @@ interface CerberusUserInterface
      *
      * @return bool
      */
-    public function can($permission, $requireAll = false);
+    public function hasPermission($permission, $requireAll = false);
 
     /**
      * Checks role(s) and permission(s).

--- a/src/Cerberus/Middleware/CerberusPermission.php
+++ b/src/Cerberus/Middleware/CerberusPermission.php
@@ -41,7 +41,7 @@ class CerberusPermission
 			$permissions = explode(self::DELIMITER, $permissions);
 		}
 
-		if ($this->auth->guest() || !$request->user()->can($permissions)) {
+		if ($this->auth->guest() || !$request->user()->hasPermission($permissions)) {
 			abort(403);
 		}
 

--- a/src/Cerberus/Middleware/CerberusRole.php
+++ b/src/Cerberus/Middleware/CerberusRole.php
@@ -37,13 +37,13 @@ class CerberusRole
      *
      * @return mixed
      */
-	public function handle($request, Closure $next, $roles, $site)
+	public function handle($request, Closure $next, $roles)
 	{
 		if (!is_array($roles)) {
 			$roles = explode(self::DELIMITER, $roles);
 		}
 
-		if ($this->auth->guest() || !$request->user()->hasRole($roles, false, $site)) {
+		if ($this->auth->guest() || !$request->user()->hasRole($roles, false)) {
 			abort(403);
 		}
 

--- a/src/Cerberus/Observers/UserObserver.php
+++ b/src/Cerberus/Observers/UserObserver.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Michalisantoniou6\Cerberus\Observers;
+
+
+use Illuminate\Cache\TaggableStore;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+
+class UserObserver
+{
+    /**
+     * Listen to the restoring event.
+     *
+     * @param $user
+     *
+     * @return void
+     */
+    public function restoring($user)
+    {
+        if (Cache::getStore() instanceof TaggableStore) {
+            Cache::tags(Config::get('cerberus.role_user_site_table'))->flush();
+        }
+    }
+
+    /**
+     * Listen to the saving event.
+     *
+     * @param $user
+     *
+     * @return void
+     */
+    public function saving($user)
+    {
+        if (Cache::getStore() instanceof TaggableStore) {
+            Cache::tags(Config::get('cerberus.role_user_site_table'))->flush();
+        }
+    }
+
+    /**
+     * Listen to the deleting event.
+     *
+     * @param  $user
+     *
+     * @return void
+     */
+    public function deleting($user)
+    {
+        if ( ! method_exists(Config::get('auth.model'), 'bootSoftDeletes')) {
+            $user->roles()->sync([]);
+        }
+
+        if (Cache::getStore() instanceof TaggableStore) {
+            Cache::tags(Config::get('cerberus.role_user_site_table'))->flush();
+        }
+    }
+}

--- a/src/Cerberus/Traits/CerberusSiteUserTrait.php
+++ b/src/Cerberus/Traits/CerberusSiteUserTrait.php
@@ -27,9 +27,48 @@ trait CerberusSiteUserTrait
      *
      * @return bool
      */
+    public function hasPermission($permission, $requireAll = false)
+    {
+        if (is_array($permission)) {
+            foreach ($permission as $permName) {
+                $hasPerm = $this->hasPermission($permName);
+
+                if ($hasPerm && ! $requireAll) {
+                    return true;
+                } elseif ( ! $hasPerm && $requireAll) {
+                    return false;
+                }
+            }
+
+            // If we've made it this far and $requireAll is FALSE, then NONE of the perms were found
+            // If we've made it this far and $requireAll is TRUE, then ALL of the perms were found.
+            // Return the value of $requireAll;
+            return $requireAll;
+        } else {
+            foreach ($this->cachedRoles() as $role) {
+                // Validate against the Permission table
+                foreach ($role->cachedPermissions() as $perm) {
+                    if (str_is($permission, $perm->name)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if user has a permission by its name.
+     *
+     * @param string|array $permission Permission string or array of permissions.
+     * @param bool $requireAll All permissions in the array are required.
+     *
+     * @return bool
+     */
     public function canForSite($permission, $site, $requireAll = false)
     {
-        if (is_a(Model::class, $site)) {
+        if (is_a(del::class, $site)) {
             $site = $site->getKey();
         }
 

--- a/src/Cerberus/Traits/CerberusUserTrait.php
+++ b/src/Cerberus/Traits/CerberusUserTrait.php
@@ -184,8 +184,7 @@ trait CerberusUserTrait
     public function roles()
     {
         return $this->belongsToMany(Config::get('cerberus.role'), Config::get('cerberus.role_user_site_table'),
-            Config::get('cerberus.user_foreign_key'), Config::get('cerberus.role_foreign_key'))
-                    ->withPivot(Config::get('cerberus.site_foreign_key'));
+            Config::get('cerberus.user_foreign_key'), Config::get('cerberus.role_foreign_key'));
     }
 
     /**
@@ -263,7 +262,7 @@ trait CerberusUserTrait
     public function detachRoles($roles = null)
     {
         if ( ! $roles) {
-            $roles = $this->roles;
+            $roles = $this->roles()->get();
         }
         foreach ($roles as $role) {
             $this->detachRole($role);

--- a/src/Cerberus/Traits/CerberusUserTrait.php
+++ b/src/Cerberus/Traits/CerberusUserTrait.php
@@ -15,52 +15,6 @@ use InvalidArgumentException;
 
 trait CerberusUserTrait
 {
-    //Big block of caching functionality.
-    /**
-     * Boot the user model
-     * Attach event listener to remove the many-to-many records when trying to delete
-     * Will NOT delete any records if the user model uses soft deletes.
-     *
-     * @return void|bool
-     */
-    public static function boot()
-    {
-        parent::boot();
-
-        static::deleting(function ($user) {
-            if ( ! method_exists(Config::get('auth.model'), 'bootSoftDeletes')) {
-                $user->roles()->sync([]);
-            }
-
-            return true;
-        });
-    }
-
-    public function save(array $options = [])
-    {   //both inserts and updates
-        if (Cache::getStore() instanceof TaggableStore) {
-            Cache::tags(Config::get('cerberus.role_user_site_table'))->flush();
-        }
-
-        return parent::save($options);
-    }
-
-    public function delete(array $options = [])
-    {   //soft or hard
-        parent::delete($options);
-        if (Cache::getStore() instanceof TaggableStore) {
-            Cache::tags(Config::get('cerberus.role_user_site_table'))->flush();
-        }
-    }
-
-    public function restore()
-    {   //soft delete undo's
-        parent::restore();
-        if (Cache::getStore() instanceof TaggableStore) {
-            Cache::tags(Config::get('cerberus.role_user_site_table'))->flush();
-        }
-    }
-
     /**
      * Checks role(s) and permission(s).
      *

--- a/src/Cerberus/Traits/CerberusUserTrait.php
+++ b/src/Cerberus/Traits/CerberusUserTrait.php
@@ -59,7 +59,7 @@ trait CerberusUserTrait
             $checkedRoles[$role] = $this->hasRole($role);
         }
         foreach ($permissions as $permission) {
-            $checkedPermissions[$permission] = $this->can($permission);
+            $checkedPermissions[$permission] = $this->hasPermission($permission);
         }
         // If validate all and there is a false in either
         // Check that if validate all, then there should not be any false.
@@ -149,11 +149,11 @@ trait CerberusUserTrait
      *
      * @return bool
      */
-    public function can($permission, $requireAll = false)
+    public function hasPermission($permission, $requireAll = false)
     {
         if (is_array($permission)) {
             foreach ($permission as $permName) {
-                $hasPerm = $this->can($permName);
+                $hasPerm = $this->hasPermission($permName);
 
                 if ($hasPerm && ! $requireAll) {
                     return true;

--- a/src/views/generators/migration.blade.php
+++ b/src/views/generators/migration.blade.php
@@ -14,14 +14,16 @@ class CerberusSetupTables extends Migration
     {
         DB::beginTransaction();
 
-        // Create table for storing roles
-        Schema::create('{{ $sitesTable }}', function (Blueprint $table) {
-            $table->increments('id');
-            $table->string('name')->unique();
-            $table->string('display_name')->nullable();
-            $table->string('description')->nullable();
-            $table->timestamps();
-        });
+        // Create table for storing sites
+        // Feel free to add/remove fields before running the migration.
+        if (!Schema::hasTable('{{ $sitesTable }}') {
+            Schema::create('{{ $sitesTable }}', function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('domain')->unique();
+                $table->string('name')->nullable();
+                $table->timestamps();
+            });
+        }
 
         // Create table for storing roles
         Schema::create('{{ $rolesTable }}', function (Blueprint $table) {

--- a/tests/CerberusTest.php
+++ b/tests/CerberusTest.php
@@ -127,12 +127,12 @@ class CerberusTest extends PHPUnit_Framework_TestCase
             ->andReturn(false)
             ->once()->ordered();
 
-        $user->shouldReceive('can')
+        $user->shouldReceive('hasPermission')
             ->with('user_can', false)
             ->andReturn(true)
             ->once();
 
-        $user->shouldReceive('can')
+        $user->shouldReceive('hasPermission')
             ->with('user_cannot', false)
             ->andReturn(false)
             ->once();
@@ -142,9 +142,9 @@ class CerberusTest extends PHPUnit_Framework_TestCase
         | Assertion
         |------------------------------------------------------------
         */
-        $this->assertTrue($cerberus->can('user_can'));
-        $this->assertFalse($cerberus->can('user_cannot'));
-        $this->assertFalse($cerberus->can('any_permission'));
+        $this->assertTrue($cerberus->hasPermission('user_can'));
+        $this->assertFalse($cerberus->hasPermission('user_cannot'));
+        $this->assertFalse($cerberus->hasPermission('any_permission'));
     }
 
     public function testUser()
@@ -343,7 +343,7 @@ class CerberusTest extends PHPUnit_Framework_TestCase
      */
     public function testFilterGeneratedByRouteNeedsPermission($returnValue, $filterTest, $abort = false, $expectedResponse = null)
     {
-        $this->filterTestExecution('routeNeedsPermission', 'can', $returnValue, $filterTest, $abort, $expectedResponse);
+        $this->filterTestExecution('routeNeedsPermission', 'hasPermission', $returnValue, $filterTest, $abort, $expectedResponse);
     }
 
     protected function filterTestExecution($methodTested, $mockedMethod, $returnValue, $filterTest, $abort, $expectedResponse)
@@ -401,7 +401,7 @@ class CerberusTest extends PHPUnit_Framework_TestCase
     ) {
         $app         = m::mock('Illuminate\Foundation\Application');
         $app->router = m::mock('Route');
-        $cerberus     = m::mock('Michalisantoniou6\Cerberus\Cerberus[hasRole, can]', [$app]);
+        $cerberus     = m::mock('Michalisantoniou6\Cerberus\Cerberus[hasRole, hasPermission]', [$app]);
 
         // Static values
         $route      = 'route';
@@ -413,7 +413,7 @@ class CerberusTest extends PHPUnit_Framework_TestCase
         $app->router->shouldReceive('filter')->with($filterName, m::on($this->$filterTest))->once();
 
         $cerberus->shouldReceive('hasRole')->with($roleName, $requireAll)->andReturn($roleIsValid)->once();
-        $cerberus->shouldReceive('can')->with($permName, $requireAll)->andReturn($permIsValid)->once();
+        $cerberus->shouldReceive('hasPermission')->with($permName, $requireAll)->andReturn($permIsValid)->once();
 
         if ($abort) {
             $app->shouldReceive('abort')->with(403)->andThrow('Exception', 'abort')->once();

--- a/tests/CerberusUserTest.php
+++ b/tests/CerberusUserTest.php
@@ -41,7 +41,7 @@ class CerberusUserTest extends PHPUnit_Framework_TestCase
         | Set
         |------------------------------------------------------------
         */
-        $belongsToMany = m::mock('BelongsToMany');
+        $belongsToMany = new stdClass();
         $user = m::mock('HasRoleUser')->makePartial();
 
         /*
@@ -49,22 +49,18 @@ class CerberusUserTest extends PHPUnit_Framework_TestCase
         | Expectation
         |------------------------------------------------------------
         */
-        $belongsToMany->shouldReceive('withPivot')->andReturn($belongsToMany);
-
         $user->shouldReceive('belongsToMany')
-            ->with('role_table_name', 'assigned_roles_table_name', 'user_id', 'role_id')
-            ->andReturn($belongsToMany)
-            ->once();
+             ->with('role_table_name', 'assigned_roles_table_name', 'user_id', 'role_id')
+             ->andReturn($belongsToMany)
+             ->once();
 
         Config::shouldReceive('get')->once()->with('cerberus.role')
-            ->andReturn('role_table_name');
+              ->andReturn('role_table_name');
         Config::shouldReceive('get')->once()->with('cerberus.role_user_site_table')
-            ->andReturn('assigned_roles_table_name');
+              ->andReturn('assigned_roles_table_name');
         Config::shouldReceive('get')->once()->with('cerberus.user_foreign_key')
-            ->andReturn('user_id');
+              ->andReturn('user_id');
         Config::shouldReceive('get')->once()->with('cerberus.role_foreign_key')
-            ->andReturn('role_id');
-        Config::shouldReceive('get')->once()->with('cerberus.site_foreign_key')
               ->andReturn('role_id');
 
         /*
@@ -251,17 +247,17 @@ class CerberusUserTest extends PHPUnit_Framework_TestCase
         Cache::shouldReceive('getStore')->times(32)->andReturn(new ArrayStore);
 
         $user->shouldReceive('hasRole')
-            ->with(m::anyOf($userRoleNameA, $userRoleNameB), m::anyOf(true, false))
-            ->andReturn(true);
+             ->with(m::anyOf($userRoleNameA, $userRoleNameB), m::anyOf(true, false))
+             ->andReturn(true);
         $user->shouldReceive('hasRole')
-            ->with(m::anyOf($nonUserRoleNameA, $nonUserRoleNameB), m::anyOf(true, false))
-            ->andReturn(false);
+             ->with(m::anyOf($nonUserRoleNameA, $nonUserRoleNameB), m::anyOf(true, false))
+             ->andReturn(false);
         $user->shouldReceive('can')
-            ->with(m::anyOf($userPermNameA, $userPermNameB, $userPermNameC), m::anyOf(true, false))
-            ->andReturn(true);
+             ->with(m::anyOf($userPermNameA, $userPermNameB, $userPermNameC), m::anyOf(true, false))
+             ->andReturn(true);
         $user->shouldReceive('can')
-            ->with(m::anyOf($nonUserPermNameA, $nonUserPermNameB), m::anyOf(true, false))
-            ->andReturn(false);
+             ->with(m::anyOf($nonUserPermNameA, $nonUserPermNameB), m::anyOf(true, false))
+             ->andReturn(false);
 
         /*
         |------------------------------------------------------------
@@ -375,17 +371,17 @@ class CerberusUserTest extends PHPUnit_Framework_TestCase
         Cache::shouldReceive('getStore')->times(32)->andReturn(new ArrayStore);
 
         $user->shouldReceive('hasRole')
-            ->with(m::anyOf($userRoleNameA, $userRoleNameB), m::anyOf(true, false))
-            ->andReturn(true);
+             ->with(m::anyOf($userRoleNameA, $userRoleNameB), m::anyOf(true, false))
+             ->andReturn(true);
         $user->shouldReceive('hasRole')
-            ->with(m::anyOf($nonUserRoleNameA, $nonUserRoleNameB), m::anyOf(true, false))
-            ->andReturn(false);
+             ->with(m::anyOf($nonUserRoleNameA, $nonUserRoleNameB), m::anyOf(true, false))
+             ->andReturn(false);
         $user->shouldReceive('can')
-            ->with(m::anyOf($userPermNameA, $userPermNameB, $userPermNameC), m::anyOf(true, false))
-            ->andReturn(true);
+             ->with(m::anyOf($userPermNameA, $userPermNameB, $userPermNameC), m::anyOf(true, false))
+             ->andReturn(true);
         $user->shouldReceive('can')
-            ->with(m::anyOf($nonUserPermNameA, $nonUserPermNameB), m::anyOf(true, false))
-            ->andReturn(false);
+             ->with(m::anyOf($nonUserPermNameA, $nonUserPermNameB), m::anyOf(true, false))
+             ->andReturn(false);
 
         /*
         |------------------------------------------------------------
@@ -537,17 +533,17 @@ class CerberusUserTest extends PHPUnit_Framework_TestCase
         Cache::shouldReceive('getStore')->times(32)->andReturn(new ArrayStore);
 
         $user->shouldReceive('hasRole')
-            ->with(m::anyOf($userRoleNameA, $userRoleNameB), m::anyOf(true, false))
-            ->andReturn(true);
+             ->with(m::anyOf($userRoleNameA, $userRoleNameB), m::anyOf(true, false))
+             ->andReturn(true);
         $user->shouldReceive('hasRole')
-            ->with(m::anyOf($nonUserRoleNameA, $nonUserRoleNameB), m::anyOf(true, false))
-            ->andReturn(false);
+             ->with(m::anyOf($nonUserRoleNameA, $nonUserRoleNameB), m::anyOf(true, false))
+             ->andReturn(false);
         $user->shouldReceive('can')
-            ->with(m::anyOf($userPermNameA, $userPermNameB, $userPermNameC), m::anyOf(true, false))
-            ->andReturn(true);
+             ->with(m::anyOf($userPermNameA, $userPermNameB, $userPermNameC), m::anyOf(true, false))
+             ->andReturn(true);
         $user->shouldReceive('can')
-            ->with(m::anyOf($nonUserPermNameA, $nonUserPermNameB), m::anyOf(true, false))
-            ->andReturn(false);
+             ->with(m::anyOf($nonUserPermNameA, $nonUserPermNameB), m::anyOf(true, false))
+             ->andReturn(false);
 
         /*
         |------------------------------------------------------------
@@ -713,17 +709,17 @@ class CerberusUserTest extends PHPUnit_Framework_TestCase
         Cache::shouldReceive('getStore')->times(8)->andReturn(new ArrayStore);
 
         $user->shouldReceive('hasRole')
-            ->with(m::anyOf('UserRoleA', 'UserRoleB'), m::anyOf(true, false))
-            ->andReturn(true);
+             ->with(m::anyOf('UserRoleA', 'UserRoleB'), m::anyOf(true, false))
+             ->andReturn(true);
         $user->shouldReceive('hasRole')
-            ->with('NonUserRoleB', m::anyOf(true, false))
-            ->andReturn(false);
+             ->with('NonUserRoleB', m::anyOf(true, false))
+             ->andReturn(false);
         $user->shouldReceive('can')
-            ->with(m::anyOf('user_can_a', 'user_can_b', 'user_can_c'), m::anyOf(true, false))
-            ->andReturn(true);
+             ->with(m::anyOf('user_can_a', 'user_can_b', 'user_can_c'), m::anyOf(true, false))
+             ->andReturn(true);
         $user->shouldReceive('can')
-            ->with('user_cannot_b', m::anyOf(true, false))
-            ->andReturn(false);
+             ->with('user_cannot_b', m::anyOf(true, false))
+             ->andReturn(false);
 
         /*
         |------------------------------------------------------------
@@ -789,17 +785,17 @@ class CerberusUserTest extends PHPUnit_Framework_TestCase
         Cache::shouldReceive('getStore')->times(32)->andReturn(new ArrayStore);
 
         $user->shouldReceive('hasRole')
-            ->with(m::anyOf($userRoleNameA, $userRoleNameB), m::anyOf(true, false))
-            ->andReturn(true);
+             ->with(m::anyOf($userRoleNameA, $userRoleNameB), m::anyOf(true, false))
+             ->andReturn(true);
         $user->shouldReceive('hasRole')
-            ->with(m::anyOf($nonUserRoleNameA, $nonUserRoleNameB), m::anyOf(true, false))
-            ->andReturn(false);
+             ->with(m::anyOf($nonUserRoleNameA, $nonUserRoleNameB), m::anyOf(true, false))
+             ->andReturn(false);
         $user->shouldReceive('can')
-            ->with(m::anyOf($userPermNameA, $userPermNameB, $userPermNameC), m::anyOf(true, false))
-            ->andReturn(true);
+             ->with(m::anyOf($userPermNameA, $userPermNameB, $userPermNameC), m::anyOf(true, false))
+             ->andReturn(true);
         $user->shouldReceive('can')
-            ->with(m::anyOf($nonUserPermNameA, $nonUserPermNameB), m::anyOf(true, false))
-            ->andReturn(false);
+             ->with(m::anyOf($nonUserPermNameA, $nonUserPermNameB), m::anyOf(true, false))
+             ->andReturn(false);
 
         /*
         |------------------------------------------------------------
@@ -902,9 +898,9 @@ class CerberusUserTest extends PHPUnit_Framework_TestCase
         |------------------------------------------------------------
         */
         $user->shouldReceive('hasRole')
-            ->times(3);
+             ->times(3);
         $user->shouldReceive('can')
-            ->times(3);
+             ->times(3);
 
         /*
         |------------------------------------------------------------
@@ -935,19 +931,19 @@ class CerberusUserTest extends PHPUnit_Framework_TestCase
         |------------------------------------------------------------
         */
         $roleObject->shouldReceive('getKey')
-            ->andReturn(1);
+                   ->andReturn(1);
 
         $user->shouldReceive('roles')
-            ->andReturn($user);
+             ->andReturn($user);
         $user->shouldReceive('attach')
-            ->with(1)
-            ->once()->ordered();
+             ->with(1)
+             ->once()->ordered();
         $user->shouldReceive('attach')
-            ->with(2)
-            ->once()->ordered();
+             ->with(2)
+             ->once()->ordered();
         $user->shouldReceive('attach')
-            ->with(3)
-            ->once()->ordered();
+             ->with(3)
+             ->once()->ordered();
 
         /*
         |------------------------------------------------------------
@@ -977,19 +973,19 @@ class CerberusUserTest extends PHPUnit_Framework_TestCase
         |------------------------------------------------------------
         */
         $roleObject->shouldReceive('getKey')
-            ->andReturn(1);
+                   ->andReturn(1);
 
         $user->shouldReceive('roles')
-            ->andReturn($user);
+             ->andReturn($user);
         $user->shouldReceive('detach')
-            ->with(1)
-            ->once()->ordered();
+             ->with(1)
+             ->once()->ordered();
         $user->shouldReceive('detach')
-            ->with(2)
-            ->once()->ordered();
+             ->with(2)
+             ->once()->ordered();
         $user->shouldReceive('detach')
-            ->with(3)
-            ->once()->ordered();
+             ->with(3)
+             ->once()->ordered();
 
 
         /*
@@ -1017,14 +1013,14 @@ class CerberusUserTest extends PHPUnit_Framework_TestCase
         |------------------------------------------------------------
         */
         $user->shouldReceive('attachRole')
-            ->with(1)
-            ->once()->ordered();
+             ->with(1)
+             ->once()->ordered();
         $user->shouldReceive('attachRole')
-            ->with(2)
-            ->once()->ordered();
+             ->with(2)
+             ->once()->ordered();
         $user->shouldReceive('attachRole')
-            ->with(3)
-            ->once()->ordered();
+             ->with(3)
+             ->once()->ordered();
 
         /*
         |------------------------------------------------------------
@@ -1049,14 +1045,14 @@ class CerberusUserTest extends PHPUnit_Framework_TestCase
         |------------------------------------------------------------
         */
         $user->shouldReceive('detachRole')
-            ->with(1)
-            ->once()->ordered();
+             ->with(1)
+             ->once()->ordered();
         $user->shouldReceive('detachRole')
-            ->with(2)
-            ->once()->ordered();
+             ->with(2)
+             ->once()->ordered();
         $user->shouldReceive('detachRole')
-            ->with(3)
-            ->once()->ordered();
+             ->with(3)
+             ->once()->ordered();
 
         /*
         |------------------------------------------------------------
@@ -1079,11 +1075,24 @@ class CerberusUserTest extends PHPUnit_Framework_TestCase
         $user = m::mock('HasRoleUser')->makePartial();
         $user->roles = [$roleA, $roleB];
 
+        $relationship = m::mock('BelongsToMany');
+
         /*
         |------------------------------------------------------------
         | Expectation
         |------------------------------------------------------------
         */
+        Config::shouldReceive('get')->with('cerberus.role')->once()->andReturn('App\Role');
+        Config::shouldReceive('get')->with('cerberus.role_user_site_table')->once()->andReturn('role_user');
+        Config::shouldReceive('get')->with('cerberus.user_foreign_key')->once()->andReturn('user_id');
+        Config::shouldReceive('get')->with('cerberus.role_foreign_key')->once()->andReturn('role_id');
+
+        $relationship->shouldReceive('get')
+                     ->andReturn($user->roles)->once();
+
+        $user->shouldReceive('belongsToMany')
+             ->andReturn($relationship)->once();
+
         $user->shouldReceive('detachRole')->twice();
 
         /*

--- a/tests/CerberusUserTest.php
+++ b/tests/CerberusUserTest.php
@@ -146,15 +146,15 @@ class CerberusUserTest extends PHPUnit_Framework_TestCase
         | Assertion
         |------------------------------------------------------------
         */
-        $this->assertTrue($user->can('manage_a'));
-        $this->assertTrue($user->can('manage_b'));
-        $this->assertTrue($user->can('manage_c'));
-        $this->assertFalse($user->can('manage_d'));
+        $this->assertTrue($user->hasPermission('manage_a'));
+        $this->assertTrue($user->hasPermission('manage_b'));
+        $this->assertTrue($user->hasPermission('manage_c'));
+        $this->assertFalse($user->hasPermission('manage_d'));
 
-        $this->assertTrue($user->can(['manage_a', 'manage_b', 'manage_c']));
-        $this->assertTrue($user->can(['manage_a', 'manage_b', 'manage_d']));
-        $this->assertFalse($user->can(['manage_a', 'manage_b', 'manage_d'], true));
-        $this->assertFalse($user->can(['manage_d', 'manage_e']));
+        $this->assertTrue($user->hasPermission(['manage_a', 'manage_b', 'manage_c']));
+        $this->assertTrue($user->hasPermission(['manage_a', 'manage_b', 'manage_d']));
+        $this->assertFalse($user->hasPermission(['manage_a', 'manage_b', 'manage_d'], true));
+        $this->assertFalse($user->hasPermission(['manage_d', 'manage_e']));
     }
 
 
@@ -192,13 +192,13 @@ class CerberusUserTest extends PHPUnit_Framework_TestCase
         | Assertion
         |------------------------------------------------------------
         */
-        $this->assertTrue($user->can('admin.posts'));
-        $this->assertTrue($user->can('admin.pages'));
-        $this->assertTrue($user->can('admin.users'));
-        $this->assertFalse($user->can('admin.config'));
+        $this->assertTrue($user->hasPermission('admin.posts'));
+        $this->assertTrue($user->hasPermission('admin.pages'));
+        $this->assertTrue($user->hasPermission('admin.users'));
+        $this->assertFalse($user->hasPermission('admin.config'));
 
-        $this->assertTrue($user->can(['admin.*']));
-        $this->assertFalse($user->can(['site.*']));
+        $this->assertTrue($user->hasPermission(['admin.*']));
+        $this->assertFalse($user->hasPermission(['site.*']));
     }
 
 
@@ -252,10 +252,10 @@ class CerberusUserTest extends PHPUnit_Framework_TestCase
         $user->shouldReceive('hasRole')
              ->with(m::anyOf($nonUserRoleNameA, $nonUserRoleNameB), m::anyOf(true, false))
              ->andReturn(false);
-        $user->shouldReceive('can')
+        $user->shouldReceive('hasPermission')
              ->with(m::anyOf($userPermNameA, $userPermNameB, $userPermNameC), m::anyOf(true, false))
              ->andReturn(true);
-        $user->shouldReceive('can')
+        $user->shouldReceive('hasPermission')
              ->with(m::anyOf($nonUserPermNameA, $nonUserPermNameB), m::anyOf(true, false))
              ->andReturn(false);
 
@@ -376,10 +376,10 @@ class CerberusUserTest extends PHPUnit_Framework_TestCase
         $user->shouldReceive('hasRole')
              ->with(m::anyOf($nonUserRoleNameA, $nonUserRoleNameB), m::anyOf(true, false))
              ->andReturn(false);
-        $user->shouldReceive('can')
+        $user->shouldReceive('hasPermission')
              ->with(m::anyOf($userPermNameA, $userPermNameB, $userPermNameC), m::anyOf(true, false))
              ->andReturn(true);
-        $user->shouldReceive('can')
+        $user->shouldReceive('hasPermission')
              ->with(m::anyOf($nonUserPermNameA, $nonUserPermNameB), m::anyOf(true, false))
              ->andReturn(false);
 
@@ -538,10 +538,10 @@ class CerberusUserTest extends PHPUnit_Framework_TestCase
         $user->shouldReceive('hasRole')
              ->with(m::anyOf($nonUserRoleNameA, $nonUserRoleNameB), m::anyOf(true, false))
              ->andReturn(false);
-        $user->shouldReceive('can')
+        $user->shouldReceive('hasPermission')
              ->with(m::anyOf($userPermNameA, $userPermNameB, $userPermNameC), m::anyOf(true, false))
              ->andReturn(true);
-        $user->shouldReceive('can')
+        $user->shouldReceive('hasPermission')
              ->with(m::anyOf($nonUserPermNameA, $nonUserPermNameB), m::anyOf(true, false))
              ->andReturn(false);
 
@@ -714,10 +714,10 @@ class CerberusUserTest extends PHPUnit_Framework_TestCase
         $user->shouldReceive('hasRole')
              ->with('NonUserRoleB', m::anyOf(true, false))
              ->andReturn(false);
-        $user->shouldReceive('can')
+        $user->shouldReceive('hasPermission')
              ->with(m::anyOf('user_can_a', 'user_can_b', 'user_can_c'), m::anyOf(true, false))
              ->andReturn(true);
-        $user->shouldReceive('can')
+        $user->shouldReceive('hasPermission')
              ->with('user_cannot_b', m::anyOf(true, false))
              ->andReturn(false);
 
@@ -790,10 +790,10 @@ class CerberusUserTest extends PHPUnit_Framework_TestCase
         $user->shouldReceive('hasRole')
              ->with(m::anyOf($nonUserRoleNameA, $nonUserRoleNameB), m::anyOf(true, false))
              ->andReturn(false);
-        $user->shouldReceive('can')
+        $user->shouldReceive('hasPermission')
              ->with(m::anyOf($userPermNameA, $userPermNameB, $userPermNameC), m::anyOf(true, false))
              ->andReturn(true);
-        $user->shouldReceive('can')
+        $user->shouldReceive('hasPermission')
              ->with(m::anyOf($nonUserPermNameA, $nonUserPermNameB), m::anyOf(true, false))
              ->andReturn(false);
 
@@ -899,7 +899,7 @@ class CerberusUserTest extends PHPUnit_Framework_TestCase
         */
         $user->shouldReceive('hasRole')
              ->times(3);
-        $user->shouldReceive('can')
+        $user->shouldReceive('hasPermission')
              ->times(3);
 
         /*

--- a/tests/Middleware/CerberusPermissionTest.php
+++ b/tests/Middleware/CerberusPermissionTest.php
@@ -23,7 +23,7 @@ class CerberusPermissionTest extends MiddlewareTest
         |------------------------------------------------------------
         */
         $guard->shouldReceive('guest')->andReturn(true);
-        $request->user()->shouldReceive('can')->andReturn(false);
+        $request->user()->shouldReceive('hasPermission')->andReturn(false);
 
         $middleware->handle($request, function () {}, null, null, true);
 
@@ -53,7 +53,7 @@ class CerberusPermissionTest extends MiddlewareTest
         |------------------------------------------------------------
         */
         $guard->shouldReceive('guest')->andReturn(true);
-        $request->user()->shouldReceive('can')->andReturn(true);
+        $request->user()->shouldReceive('hasPermission')->andReturn(true);
 
         $middleware->handle($request, function () {}, null, null);
 
@@ -83,7 +83,7 @@ class CerberusPermissionTest extends MiddlewareTest
         |------------------------------------------------------------
         */
         $guard->shouldReceive('guest')->andReturn(false);
-        $request->user()->shouldReceive('can')->andReturn(false);
+        $request->user()->shouldReceive('hasPermission')->andReturn(false);
 
         $middleware->handle($request, function () {}, null, null);
 
@@ -113,7 +113,7 @@ class CerberusPermissionTest extends MiddlewareTest
         |------------------------------------------------------------
         */
         $guard->shouldReceive('guest')->andReturn(false);
-        $request->user()->shouldReceive('can')->andReturn(true);
+        $request->user()->shouldReceive('hasPermission')->andReturn(true);
 
         $middleware->handle($request, function () {}, null, null);
 

--- a/tests/Middleware/MiddlewareTest.php
+++ b/tests/Middleware/MiddlewareTest.php
@@ -13,7 +13,7 @@ abstract class MiddlewareTest extends PHPUnit_Framework_TestCase
 		     * Mimicks Laravel5's abort() helper function.
 		     *
 		     * Instead of calling \Illuminate\Foundation\Application::abort(), this function keeps track of 
-		     * the last abort called, so the abort can be retrieved for test assertions.
+		     * the last abort called, so the abort hasPermission be retrieved for test assertions.
 		     *
 		     * @see https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/helpers.php#L7-L23
 		     *


### PR DESCRIPTION
Major Changes:
 - Replaces can() with hasPermission() to avoid conflict with Laravel's Authorizable Contract
 - Adds hasPermission() to CerberusSiteUserTrait to check for permissions globally *.
 - Adds hasRole() to CerberusSiteUserTrait to check for permissions globally *.
 - Moves model event listeners to an Observer to avoid hang to specify when used with SoftDeletes

* This is to allow for roles to have the capability of accessing all sites. For example, role Superadmin may have access to all sites, so it's easier to use SuperadminUser->hasRole('superadmin'), instead of SuperadminUser->hasRoleForSite('superadmin', $site).
Note: Non site specific users (Super Users) will need a `site_id`in table `role_user_site`, unless site_id was set to nullable() before running the migration.